### PR TITLE
fix: `with` instead of `env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: yogevbd/enforce-label-action@2.0.0
-      env:
+      with:
         REQUIRED_LABELS_ANY: "bug,enhancement,wontfix"
         REQUIRED_LABELS_ALL: "required"
         BANNED_LABELS: "banned"


### PR DESCRIPTION
I encountered this bug while using it for my own github actions.